### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.bomber.json
+++ b/org.kde.bomber.json
@@ -16,6 +16,8 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
         "/share/doc",
         "/share/qlogging-categories6"
     ],


### PR DESCRIPTION
This PR removes the /share/carddecks folder, which is not required for this game.